### PR TITLE
fix: consistent get manifest

### DIFF
--- a/sdk/streaming_writer.go
+++ b/sdk/streaming_writer.go
@@ -294,8 +294,8 @@ func (w *StreamingWriter) Finalize(ctx context.Context, attributeFQNs []string, 
 // GetManifest returns the current manifest snapshot from the underlying writer.
 // Before finalize, this is a provisional manifest (informational only). After
 // finalize, it is the final manifest.
-func (w *StreamingWriter) GetManifest() *tdf.Manifest {
-	return w.writer.GetManifest()
+func (w *StreamingWriter) GetManifest(ctx context.Context) (*tdf.Manifest, error) {
+	return w.writer.GetManifest(ctx)
 }
 
 // fetchAttributesByFQNs retrieves attribute values from the platform by their FQNs.

--- a/sdk/tdf/writer.go
+++ b/sdk/tdf/writer.go
@@ -446,9 +446,6 @@ func (w *Writer) getManifest(ctx context.Context, cfg *WriterFinalizeConfig) (*M
 	// Determine finalize order by collecting all present segment indices and sorting.
 	// This densifies sparse indices automatically and ignores any gaps.
 	order := make([]int, 0, len(w.segments))
-	if len(w.segments) == 0 {
-		return nil, 0, 0, errors.New("no segments written")
-	}
 	for idx := range w.segments {
 		order = append(order, idx)
 	}
@@ -471,17 +468,6 @@ func (w *Writer) getManifest(ctx context.Context, cfg *WriterFinalizeConfig) (*M
 			subset = append(subset, idx)
 		}
 		order = subset
-	}
-	// Require index 0 for now (header emission on segment 0)
-	hasZero := false
-	for _, v := range order {
-		if v == 0 {
-			hasZero = true
-			break
-		}
-	}
-	if !hasZero {
-		return nil, 0, 0, fmt.Errorf("segment 0 is required for header emission; got order without 0: %v", order)
 	}
 
 	// Generate splits using the splitter

--- a/sdk/tdf/writer.go
+++ b/sdk/tdf/writer.go
@@ -403,12 +403,16 @@ func (w *Writer) Finalize(ctx context.Context, opts ...Option[*WriterFinalizeCon
 func (w *Writer) GetManifest(ctx context.Context, opts ...Option[*WriterFinalizeConfig]) (*Manifest, error) {
 	w.mutex.RLock()
 	defer w.mutex.RUnlock()
-
-	manifest, _, _, err := w.getManifest(ctx, &WriterFinalizeConfig{
+	cfg := &WriterFinalizeConfig{
 		attributes:        make([]*policy.Value, 0),
 		encryptedMetadata: "",
 		payloadMimeType:   "application/octet-stream",
-	})
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	manifest, _, _, err := w.getManifest(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/tdf/writer.go
+++ b/sdk/tdf/writer.go
@@ -163,7 +163,7 @@ func NewWriter(_ context.Context, opts ...Option[*WriterConfig]) (*Writer, error
 	}
 
 	// Initialize archive writer - start with 1 segment and expand dynamically
-	archiveWriter := archive.NewSegmentTDFWriter(1)
+	archiveWriter := archive.NewSegmentTDFWriter(1, archive.WithZip64())
 
 	// Generate DEK
 	dek, err := ocrypto.RandomBytes(kKeySize)


### PR DESCRIPTION
changes:

- GetManifest: to ensure that the expected `GetManifest` from `Finalize` is the same, i make sure they reference the same helper `getManifest`. 
- Allowing non zero segments/empty segment list. This is needed in S4 for getting predictable segment sizes
- always use zip64, i found that if the file isn't initially zip64, but later is required to be zip64 due to large payload, the TDF readers will not be able to decrypt it. 